### PR TITLE
Adjust interactive launch syntax and testing to mqttwarn 0.26.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pip install .[test]
+        pip install .[test] --upgrade
         pytest tests
 
     - name: Generate coverage report

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,13 @@ mqttwarn-contrib changelog
 in progress
 ===========
 
+
+2021-06-19 0.2.0
+================
+
 - [cloudflare_zone] Improve logging
 - [cloudflare_zone] Document how to invoke the plugin interactively
+- Adjust interactive launch syntax and testing to mqttwarn 0.26.0
 
 
 2021-06-19 0.1.0

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -102,20 +102,9 @@ def publish_public_ip_address(srv=None):
 
 `mqttwarn` has an option to invoke notification handler plugins interactively.
 
-Currently, this still needs a minimal configuration file like `standalone.ini`:
-```ini
-[defaults]
-logfile   = 'stream://sys.stderr'
-loglevel  = DEBUG
-
-[config:mqttwarn_contrib.services.cloudflare_zone]
-auth-email  = '<your cloudflare@email.address>'
-auth-key    = '<your cloudflare api key>'
-```
-
 ```shell
 mqttwarn \
-    --config=standalone.ini \
     --plugin=mqttwarn_contrib.services.cloudflare_zone \
-    --data='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
+    --config='{"auth-email": "foo", "auth-key": "bar"}' \
+    --options='{"addrs": ["0815", "www.example.org", ""], "message": "192.168.0.1"}'
 ```

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras = {}
 
 # Packages needed for running the tests.
 extras["test"] = [
-    'mqttwarn[test]',
+    'mqttwarn[test]>=0.26.0',
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,2 @@
-# FIXME: Refactor this to `mqttwarn.testing.conftest`.
-import logging
-
-import pytest
-
-from mqttwarn.core import Service
-
-
-@pytest.fixture
-def srv():
-    """
-    A service instance for propagating to the plugin.
-    """
-    logger = logging.getLogger(__name__)
-    return Service(mqttc=None, logger=logger)
+# Import fixtures
+from mqttwarn.testing.fixtures import mqttwarn_service as srv  # noqa

--- a/tests/test_cloudflare_zone.py
+++ b/tests/test_cloudflare_zone.py
@@ -3,7 +3,7 @@ import logging
 import responses
 
 from mqttwarn.util import load_module_from_file
-from tests.util import ProcessorItem as Item
+from mqttwarn.model import ProcessorItem as Item
 
 
 def add_successful_mock_response():


### PR DESCRIPTION
Hi there,

this patch depends on both https://github.com/jpmens/mqttwarn/pull/534 and https://github.com/jpmens/mqttwarn/pull/535. It will improve the convenience on using mqttwarn.

With kind regards,
Andreas.